### PR TITLE
Add a "datastore-cleanup" command

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/ckanext/datalocale/commands.py
+++ b/ckanext/datalocale/commands.py
@@ -75,11 +75,10 @@ class DataStoreCleanup(ckan.lib.cli.CkanCommand):
 
         resource_id_list = []
         for record in result['records']:
+            # ignore 'alias' records
+            if record.get('alias_of'):
+                continue
             try:
-                # ignore 'alias' records
-                if record['alias_of']:
-                    continue
-
                 logic.get_action('resource_show')(
                     context,
                     {'id': record['name']}
@@ -88,8 +87,6 @@ class DataStoreCleanup(ckan.lib.cli.CkanCommand):
             except logic.NotFound:
                 resource_id_list.append(record['name'])
                 print("Resource '%s' *not* found" % record['name'])
-            except KeyError:
-                continue
 
         # are there more records?
         has_next_page = (len(result['records']) > 0)

--- a/ckanext/datalocale/commands.py
+++ b/ckanext/datalocale/commands.py
@@ -27,18 +27,13 @@ class DatalocaleCommand(ckan.lib.cli.CkanCommand):
     def command(self):
         options = {
             'cleanup_datastore': self.cleanup_datastore,
-            'help': self.help,
         }
 
+        cmd = self.args[0]
         try:
-            cmd = self.args[0]
             options[cmd](*self.args[1:])
         except KeyError:
-            self.help()
-            sys.exit(1)
-
-    def help(self):
-        print(self.__doc__)
+            self.parser.error("unknown command '%s'" % cmd)
 
     def cleanup_datastore(self):
         # load pylons config

--- a/ckanext/datalocale/commands.py
+++ b/ckanext/datalocale/commands.py
@@ -87,6 +87,9 @@ class DataStoreCleanup(ckan.lib.cli.CkanCommand):
             except logic.NotFound:
                 resource_id_list.append(record['name'])
                 print("Resource '%s' *not* found" % record['name'])
+            except Exception as exc:
+                print("ERROR during 'resource_show' call for %s: %s"
+                      % (record['name'], exc))
 
         # are there more records?
         has_next_page = (len(result['records']) > 0)

--- a/ckanext/datalocale/commands.py
+++ b/ckanext/datalocale/commands.py
@@ -1,0 +1,103 @@
+from __future__ import print_function
+
+import sys
+import itertools
+import ckan.lib.cli
+import ckan.logic as logic
+import ckan.model as model
+
+
+class DatalocaleCommand(ckan.lib.cli.CkanCommand):
+    """datalocale admin commands
+
+    cleanup_datastore   - clean the datastore db from non-existent resources tables
+    """
+    # Copied from ckanext-switzerland at f00d848f022a9080f4aef36ed305fa73292fdb28
+    summary = __doc__.split('\n')[0]
+    usage = __doc__
+
+    def command(self):
+        # load pylons config
+        self._load_config()
+        options = {
+            'cleanup_datastore': self.cleanup_datastore,
+            'help': self.help,
+        }
+
+        try:
+            cmd = self.args[0]
+            options[cmd](*self.args[1:])
+        except KeyError:
+            self.help()
+            sys.exit(1)
+
+    def help(self):
+        print(self.__doc__)
+
+    def cleanup_datastore(self):
+        user = logic.get_action('get_site_user')({'ignore_auth': True}, {})
+        context = {
+            'model': model,
+            'session': model.Session,
+            'user': user['name']
+        }
+        try:
+            logic.check_access('datastore_delete', context)
+            logic.check_access('resource_show', context)
+        except logic.NotAuthorized:
+            print("User {} is not authorized to perform this action.".format(user['name']))
+            sys.exit(1)
+
+        # query datastore to get all resources from the _table_metadata
+        resource_id_list = []
+        for offset in itertools.count(start=0, step=100):
+            print("Load metadata records from datastore (offset: %s)" % offset)
+            record_list, has_next_page = self._get_datastore_table_page(context, offset)  # noqa
+            resource_id_list.extend(record_list)
+            if not has_next_page:
+                break
+
+        # delete the rows of the orphaned datastore tables
+        delete_count = 0
+        for resource_id in resource_id_list:
+            logic.get_action('datastore_delete')(
+                context,
+                {'resource_id': resource_id, 'force': True}
+            )
+            print("Table '%s' deleted (not dropped)" % resource_id)
+            delete_count += 1
+
+        print("Deleted content of %s tables" % delete_count)
+
+    def _get_datastore_table_page(self, context, offset=0):
+        # query datastore to get all resources from the _table_metadata
+        result = logic.get_action('datastore_search')(
+            context,
+            {
+                'resource_id': '_table_metadata',
+                'offset': offset
+            }
+        )
+
+        resource_id_list = []
+        for record in result['records']:
+            try:
+                # ignore 'alias' records
+                if record['alias_of']:
+                    continue
+
+                logic.get_action('resource_show')(
+                    context,
+                    {'id': record['name']}
+                )
+                print("Resource '%s' found" % record['name'])
+            except logic.NotFound:
+                resource_id_list.append(record['name'])
+                print("Resource '%s' *not* found" % record['name'])
+            except KeyError:
+                continue
+
+        # are there more records?
+        has_next_page = (len(result['records']) > 0)
+
+        return resource_id_list, has_next_page

--- a/ckanext/datalocale/commands.py
+++ b/ckanext/datalocale/commands.py
@@ -7,17 +7,13 @@ import ckan.logic as logic
 import ckan.model as model
 
 
-class DatalocaleCommand(ckan.lib.cli.CkanCommand):
-    """datalocale admin commands
-
-    cleanup_datastore   - clean the datastore db from non-existent resources tables
-    """
+class DataStoreCleanup(ckan.lib.cli.CkanCommand):
+    """Clean the datastore db from non-existent resources tables"""
     # Copied from ckanext-switzerland at f00d848f022a9080f4aef36ed305fa73292fdb28
-    summary = __doc__.split('\n')[0]
-    usage = __doc__
+    summary = __doc__
 
     def __init__(self, name):
-        super(DatalocaleCommand, self).__init__(name)
+        super(DataStoreCleanup, self).__init__(name)
         self.parser.add_option(
             '-n', '--dry-run', dest='dry_run',
             action='store_true', default=False,
@@ -25,17 +21,6 @@ class DatalocaleCommand(ckan.lib.cli.CkanCommand):
         )
 
     def command(self):
-        options = {
-            'cleanup_datastore': self.cleanup_datastore,
-        }
-
-        cmd = self.args[0]
-        try:
-            options[cmd](*self.args[1:])
-        except KeyError:
-            self.parser.error("unknown command '%s'" % cmd)
-
-    def cleanup_datastore(self):
         # load pylons config
         self._load_config()
         user = logic.get_action('get_site_user')({'ignore_auth': True}, {})

--- a/ckanext/datalocale/commands.py
+++ b/ckanext/datalocale/commands.py
@@ -37,11 +37,13 @@ class DataStoreCleanup(ckan.lib.cli.CkanCommand):
             sys.exit(1)
 
         dry_run = self.options.dry_run
+        verbose = self.options.verbose
 
         # query datastore to get all resources from the _table_metadata
         resource_id_list = []
         for offset in itertools.count(start=0, step=100):
-            print("Load metadata records from datastore (offset: %s)" % offset)
+            if verbose:
+                print("Load metadata records from datastore (offset: %s)" % offset)
             record_list, has_next_page = self._get_datastore_table_page(context, offset)  # noqa
             resource_id_list.extend(record_list)
             if not has_next_page:
@@ -64,6 +66,7 @@ class DataStoreCleanup(ckan.lib.cli.CkanCommand):
         print("Deleted content of %s tables" % delete_count)
 
     def _get_datastore_table_page(self, context, offset=0):
+        verbose = self.options.verbose
         # query datastore to get all resources from the _table_metadata
         result = logic.get_action('datastore_search')(
             context,
@@ -83,7 +86,8 @@ class DataStoreCleanup(ckan.lib.cli.CkanCommand):
                     context,
                     {'id': record['name']}
                 )
-                print("Resource '%s' found" % record['name'])
+                if verbose:
+                    print("Resource '%s' found" % record['name'])
             except logic.NotFound:
                 resource_id_list.append(record['name'])
                 print("Resource '%s' *not* found" % record['name'])

--- a/ckanext/datalocale/commands.py
+++ b/ckanext/datalocale/commands.py
@@ -25,8 +25,6 @@ class DatalocaleCommand(ckan.lib.cli.CkanCommand):
         )
 
     def command(self):
-        # load pylons config
-        self._load_config()
         options = {
             'cleanup_datastore': self.cleanup_datastore,
             'help': self.help,
@@ -43,6 +41,8 @@ class DatalocaleCommand(ckan.lib.cli.CkanCommand):
         print(self.__doc__)
 
     def cleanup_datastore(self):
+        # load pylons config
+        self._load_config()
         user = logic.get_action('get_site_user')({'ignore_auth': True}, {})
         context = {
             'model': model,

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,8 @@ setup(
     entry_points='''
         [ckan.plugins]
         datalocale=ckanext.datalocale.plugin:DatalocalePlugin
+        [paste.paster_command]
+        datalocale=ckanext.datalocale.commands:DatalocaleCommand
 	[babel.extractors]
 	ckan = ckan.lib.extract:extract_ckan
     ''',

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         [ckan.plugins]
         datalocale=ckanext.datalocale.plugin:DatalocalePlugin
         [paste.paster_command]
-        datalocale=ckanext.datalocale.commands:DatalocaleCommand
+        datastore-cleanup=ckanext.datalocale.commands:DataStoreCleanup
 	[babel.extractors]
 	ckan = ckan.lib.extract:extract_ckan
     ''',


### PR DESCRIPTION
This command was copied from ckanext-switzerland and adapted to be more robust, handle a `--dry-run` option and respect `--verbose` option. 