### PR TITLE
Override the "promoted" section on home page

### DIFF
--- a/ckanext/datalocale/templates/home/snippets/promoted.html
+++ b/ckanext/datalocale/templates/home/snippets/promoted.html
@@ -1,0 +1,12 @@
+{% ckan_extends %}
+
+{% block home_image %}
+  <section class="featured media-overlay hidden-xs">
+    <h2 class="media-heading">{% block home_image_caption %}{{ _("Partageons nos ressources") }}{% endblock %}</h2>
+    {% block home_image_content %}
+      <a class="media-image" href="#">
+        <img class="img-responsive" src="{{ h.url_for_static('/img/illustration_datalocale_home.jpg') }}" alt="ressourcerie" width="420" height="220" />
+      </a>
+    {% endblock %}
+  </section>
+{% endblock %}


### PR DESCRIPTION
Especially, update section title and use the correct image.