### PR TITLE
Hide unwanted "extras" from dataset "Additional information" table

### DIFF
--- a/ckanext/datalocale/templates/package/snippets/additional_info.html
+++ b/ckanext/datalocale/templates/package/snippets/additional_info.html
@@ -1,0 +1,16 @@
+{% ckan_extends %}
+
+{% block extras scoped %}
+{% set hidden_extras = [
+      'Contact URI', 'Frequency', 'GUID',
+      'Issued', 'Modified',
+      'Publisher URI', 'Publisher name', 'Publisher type',
+      'Theme',
+    ] -%}
+  {% for key, value in h.sorted_extras(pkg_dict.extras) if key not in hidden_extras %}
+    <tr rel="dc:relation" resource="_:extra{{ i }}">
+      <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
+      <td class="dataset-details" property="rdf:value">{{ value }}</td>
+    </tr>
+  {% endfor %}
+{% endblock %}


### PR DESCRIPTION
We hide all "extra" fields coming from DCAT harvesting that are not
useful to the end user or not displayed in a meaningful manner.
This includes:

* Contact URI
* Frequency
* GUID
* Issued/Modified (redundant "metadata_created" and "metadata_modified"
  shown above in the table)
* Publisher name/URI/type (redundant with the publisher panel on the
  right side of the page).
* Theme, which is redundant with the "Themes" tab and does now renders
  well.